### PR TITLE
use CLI flags instead of sed for LightGBM GPU install

### DIFF
--- a/3-R-all-docker/gpu/Dockerfile
+++ b/3-R-all-docker/gpu/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get install -y libboost-dev libboost-system-dev libboost-filesystem-dev 
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd   ## otherwise lightgm segfaults at runtime (compiles fine without it)
 RUN git clone --recursive https://github.com/microsoft/LightGBM && \
-    cd LightGBM && sed -i "s/use_gpu <- FALSE/use_gpu <- TRUE/"  R-package/src/install.libs.R && Rscript build_r.R
+    cd LightGBM && \
+    Rscript build_r.R --use-gpu
 
 
 CMD ["R","--vanilla"]


### PR DESCRIPTION
Similar to https://github.com/szilard/GBM-perf/pull/45.

`{lightgbm}`'s CMake-based build (the non-CRAN one) no longer requires manually changing variables in `R-package/install.libs.R`. As of https://github.com/microsoft/LightGBM/pull/3574, you can pass flags like `Rscript build_r.R --use-gpu`.

This PR proposes changing the dockerfiles in this project to use that strategy, since it's less likely to be broken by future changes to `{lightgbm}`.